### PR TITLE
JWT, API 호출 예외 추가 및 코드 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,10 @@ out/
 .vscode/
 
 ### application.properties ###
-application.properties
+application.yml
+
+### MAC DS_Store ###
+.DS_Store
+._.DS_Store
+**/.DS_Store
+**/._.DS_Store

--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -2,7 +2,9 @@ package com.example.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class DemoApplication {
 

--- a/src/main/java/com/example/demo/base/Resolver/AuthorizationResolver.java
+++ b/src/main/java/com/example/demo/base/Resolver/AuthorizationResolver.java
@@ -28,11 +28,11 @@ public class AuthorizationResolver implements HandlerMethodArgumentResolver {
         Claims claims = jwtProvider.getValidToken(token);
 
         if (Long.class.equals(parameter.getParameterType())) {
-            return ((Number) claims.get("userId")).longValue();
+            return Long.valueOf(claims.get("accountId").toString());
         }
         return AccessToken.builder()
                 .token(token)
-                .accountId(((Number) claims.get("userId")).longValue())
+                .accountId(Long.valueOf(claims.get("accountId").toString()))
                 .timeToLive(claims.getExpiration())
                 .build();
     }

--- a/src/main/java/com/example/demo/base/blacklist_token/BlacklistTokenService.java
+++ b/src/main/java/com/example/demo/base/blacklist_token/BlacklistTokenService.java
@@ -4,7 +4,6 @@ import com.example.demo.base.Resolver.AccessToken;
 import com.example.demo.base.exception.CustomException;
 import com.example.demo.base.exception.ExceptionCode;
 import com.example.demo.base.jwt.JwtProvider;
-import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/example/demo/base/common/BaseTimeEntity.java
+++ b/src/main/java/com/example/demo/base/common/BaseTimeEntity.java
@@ -1,4 +1,4 @@
-package com.example.demo.base.entity;
+package com.example.demo.base.common;
 
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/src/main/java/com/example/demo/base/common/CookieProvider.java
+++ b/src/main/java/com/example/demo/base/common/CookieProvider.java
@@ -8,7 +8,7 @@ import java.time.Duration;
 @Component
 public class CookieProvider {
     public ResponseCookie generateTokenCookie(String refreshToken){
-        return ResponseCookie.from("RefreshToken", refreshToken)
+        return ResponseCookie.from(AuthConstants.REFRESH_TOKEN, refreshToken)
                 .httpOnly(true)
                 .sameSite("None")
                 .path("/")

--- a/src/main/java/com/example/demo/base/exception/ExceptionCode.java
+++ b/src/main/java/com/example/demo/base/exception/ExceptionCode.java
@@ -6,33 +6,31 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ExceptionCode {
     //access
-    EMPTY_TOKEN("TOKEN", HttpStatus.BAD_REQUEST, "헤더에 토큰이 존재하지 않습니다."),
-    INVALID_TOKEN("TOKEN", HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
-    WRONG_TOKEN("TOKEN", HttpStatus.UNAUTHORIZED, "올바르지 않은 토큰 형식입니다."),
-    EXPIRE_ACCESS_TOKEN("TOKEN", HttpStatus.UNAUTHORIZED, "만료된 토큰 입니다."),
+    EMPTY_TOKEN(HttpStatus.BAD_REQUEST, "헤더에 토큰이 존재하지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    WRONG_TOKEN(HttpStatus.UNAUTHORIZED, "올바르지 않은 토큰 형식입니다."),
+    EXPIRE_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰 입니다."),
 
     //refresh
-    EXPIRE_REFRESH_TOKEN("TOKEN", HttpStatus.UNAUTHORIZED, "만료된 토큰 입니다. 재로그인 필요"),
-    TOKEN_NOT_FOUND("TOKEN", HttpStatus.UNAUTHORIZED, "해당 토큰을 찾을 수 없습니다. 재로그인 필요"),
+    EXPIRE_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰 입니다. 재로그인 필요"),
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "해당 토큰을 찾을 수 없습니다. 재로그인 필요"),
 
     //request
-    INVALID_BODY("BODY", HttpStatus.BAD_REQUEST, "올바르지 않은 바디 값 입니다."),
-    INVALID_HEADER("HEADER", HttpStatus.BAD_REQUEST, "올바르지 않은 헤더 값 입니다."),
-    INVALID_COOKIE("COOKIE", HttpStatus.BAD_REQUEST, "올바르지 않은 쿠키 값 입니다."),
+    INVALID_BODY(HttpStatus.BAD_REQUEST, "올바르지 않은 바디 값 입니다."),
+    INVALID_HEADER(HttpStatus.BAD_REQUEST, "올바르지 않은 헤더 값 입니다."),
+    INVALID_COOKIE(HttpStatus.BAD_REQUEST, "올바르지 않은 쿠키 값 입니다."),
 
-    ACCOUNT_NOT_FOUND("AUTH", HttpStatus.BAD_REQUEST, "해당 계정이름을 찾을 수 없습니다."),
-    INVALID_PASSWORD("AUTH", HttpStatus.UNAUTHORIZED, "유효하지 않은 비밀번호 입니다."),
-    BLACK_LIST("AUTH", HttpStatus.BAD_REQUEST, "무효화된 토큰입니다."),
-    INVALID_SIGN_OUT("AUTH", HttpStatus.BAD_REQUEST, "비정상적인 로그아웃 시도입니다."),
+    ACCOUNT_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 계정이름을 찾을 수 없습니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "유효하지 않은 비밀번호 입니다."),
+    BLACK_LIST(HttpStatus.BAD_REQUEST, "무효화된 토큰입니다."),
+    INVALID_SIGN_OUT(HttpStatus.BAD_REQUEST, "비정상적인 로그아웃 시도입니다."),
 
-    DUPLICATE_NAME("CREATE", HttpStatus.BAD_REQUEST, "중복된 이름이 존재합니다.");
+    DUPLICATE_NAME(HttpStatus.BAD_REQUEST, "중복된 이름이 존재합니다.");
 
-    private String type;
     private HttpStatus status;
     private String message;
 
-    ExceptionCode(String type, HttpStatus status, String message) {
-        this.type = type;
+    ExceptionCode(HttpStatus status, String message) {
         this.status = status;
         this.message = message;
     }

--- a/src/main/java/com/example/demo/base/exception/ExceptionCode.java
+++ b/src/main/java/com/example/demo/base/exception/ExceptionCode.java
@@ -17,6 +17,8 @@ public enum ExceptionCode {
 
     //request
     INVALID_BODY("BODY", HttpStatus.BAD_REQUEST, "올바르지 않은 바디 값 입니다."),
+    INVALID_HEADER("HEADER", HttpStatus.BAD_REQUEST, "올바르지 않은 헤더 값 입니다."),
+    INVALID_COOKIE("COOKIE", HttpStatus.BAD_REQUEST, "올바르지 않은 쿠키 값 입니다."),
 
     ACCOUNT_NOT_FOUND("AUTH", HttpStatus.BAD_REQUEST, "해당 계정이름을 찾을 수 없습니다."),
     INVALID_PASSWORD("AUTH", HttpStatus.UNAUTHORIZED, "유효하지 않은 비밀번호 입니다."),

--- a/src/main/java/com/example/demo/base/exception/ExceptionResponse.java
+++ b/src/main/java/com/example/demo/base/exception/ExceptionResponse.java
@@ -10,14 +10,19 @@ import java.time.LocalDateTime;
 public class ExceptionResponse {
     private final LocalDateTime timestamp = LocalDateTime.now();
     private String type;
-    private String title;
     private String message;
 
     public static ExceptionResponse of(ExceptionCode exceptionCode) {
         return ExceptionResponse.builder()
-                .type(exceptionCode.getType())
-                .title(exceptionCode.name())
+                .type(exceptionCode.name())
                 .message(exceptionCode.getMessage())
+                .build();
+    }
+
+    public static ExceptionResponse of(Exception exception) {
+        return ExceptionResponse.builder()
+                .type("SYSTEM_EXCEPTION")
+                .message(exception.getClass().toString() + " : " + exception.getMessage())
                 .build();
     }
 }

--- a/src/main/java/com/example/demo/base/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/demo/base/exception/GlobalExceptionHandler.java
@@ -1,10 +1,15 @@
 package com.example.demo.base.exception;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.web.bind.MissingRequestCookieException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -24,9 +29,51 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
     }
 
+    /**
+     * API 요청 에러
+     */
+    //BODY
     @ExceptionHandler(HttpMessageNotReadableException.class)
     protected ResponseEntity<ExceptionResponse> handler(HttpMessageNotReadableException e) {
         ExceptionResponse response = ExceptionResponse.of(ExceptionCode.INVALID_BODY);
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    //HEADER
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    protected ResponseEntity<ExceptionResponse> handler(MissingRequestHeaderException e) {
+        ExceptionResponse response = ExceptionResponse.of(ExceptionCode.INVALID_HEADER);
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    //COOKIE
+    @ExceptionHandler(MissingRequestCookieException.class)
+    protected ResponseEntity<ExceptionResponse> handler(MissingRequestCookieException e) {
+        ExceptionResponse response = ExceptionResponse.of(ExceptionCode.INVALID_COOKIE);
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    /**
+     * JWT 관련 에러
+     */
+    //서명
+    @ExceptionHandler(SignatureException.class)
+    protected ResponseEntity<ExceptionResponse> handler(SignatureException e) {
+        ExceptionResponse response = ExceptionResponse.of(ExceptionCode.INVALID_TOKEN);
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    //형식
+    @ExceptionHandler(MalformedJwtException.class)
+    protected ResponseEntity<ExceptionResponse> handler(MalformedJwtException e) {
+        ExceptionResponse response = ExceptionResponse.of(ExceptionCode.WRONG_TOKEN);
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    //만료
+    @ExceptionHandler(ExpiredJwtException.class)
+    protected ResponseEntity<ExceptionResponse> handler(ExpiredJwtException e) {
+        ExceptionResponse response = ExceptionResponse.of(ExceptionCode.EXPIRE_ACCESS_TOKEN);
         return ResponseEntity.badRequest().body(response);
     }
 }

--- a/src/main/java/com/example/demo/base/jwt/JwtProvider.java
+++ b/src/main/java/com/example/demo/base/jwt/JwtProvider.java
@@ -27,6 +27,9 @@ public class JwtProvider {
     }
 
     public String parseToken(HttpServletRequest request) {
+        if(request.getHeader(AuthConstants.AUTH_HEADER) == null){
+            throw new CustomException(ExceptionCode.EMPTY_TOKEN);
+        }
         return parseToken(request.getHeader(AuthConstants.AUTH_HEADER));
     }
 

--- a/src/main/java/com/example/demo/base/jwt/JwtProvider.java
+++ b/src/main/java/com/example/demo/base/jwt/JwtProvider.java
@@ -15,11 +15,11 @@ public class JwtProvider {
 
     private final JwtProperties jwtProperties;
 
-    public String generatorAccessToken(Long userId){
+    public String generatorAccessToken(Long accountId){
         Date now = new Date();
         return Jwts.builder()
                 .setIssuer(jwtProperties.getIssuer())
-                .claim("userId", userId)
+                .claim("accountId", accountId)
                 .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey().getBytes())
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + jwtProperties.getAccessExpiration()))
@@ -47,5 +47,9 @@ public class JwtProvider {
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
+    }
+
+    public String getAccountId(String token){
+        return getValidToken(token).get("accountId").toString();
     }
 }

--- a/src/main/java/com/example/demo/base/refresh_token/RefreshToken.java
+++ b/src/main/java/com/example/demo/base/refresh_token/RefreshToken.java
@@ -1,17 +1,10 @@
 package com.example.demo.base.refresh_token;
 
-import com.example.demo.base.exception.CustomException;
-import com.example.demo.base.exception.ExceptionCode;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.http.ResponseCookie;
-import org.springframework.http.ResponseEntity;
-
-import java.time.Duration;
-import java.time.LocalDateTime;
 import java.util.Date;
 
 @Entity
@@ -34,14 +27,5 @@ public class RefreshToken {
     public void reIssueToken(String token, Date timeToLive){
         this.token = token;
         this.timeToLive = timeToLive;
-    }
-
-    public ResponseCookie generateCookie(){
-        return ResponseCookie.from("RefreshToken", token)
-                .httpOnly(true)
-                .sameSite("None")
-                .path("/")
-                .maxAge(Duration.ofDays(7))
-                .build();
     }
 }

--- a/src/main/java/com/example/demo/base/security/SecurityConfig.java
+++ b/src/main/java/com/example/demo/base/security/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig {
     private final JwtProvider jwtProvider;
     private final ObjectMapper objectMapper;
     private final BlacklistTokenService blacklistTokenService;
+    private final UserDetailsServiceImpl userDetailsService;
 
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -48,7 +49,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(request -> request
                         .requestMatchers("/api/account/**").authenticated()
                         .anyRequest().permitAll())
-                .addFilterBefore(new JwtTokenFilter(jwtProvider, blacklistTokenService, objectMapper), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtTokenFilter(jwtProvider, blacklistTokenService, objectMapper, userDetailsService), UsernamePasswordAuthenticationFilter.class)
                 .formLogin(withDefaults())
                 .httpBasic(withDefaults());
 

--- a/src/main/java/com/example/demo/base/security/SecurityConfig.java
+++ b/src/main/java/com/example/demo/base/security/SecurityConfig.java
@@ -14,7 +14,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 

--- a/src/main/java/com/example/demo/base/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/demo/base/security/UserDetailsServiceImpl.java
@@ -1,5 +1,8 @@
 package com.example.demo.base.security;
 
+import com.example.demo.base.exception.CustomException;
+import com.example.demo.base.exception.ExceptionCode;
+import com.example.demo.base.exception.ExceptionResponse;
 import com.example.demo.bounded_context.account.entity.Account;
 
 import com.example.demo.bounded_context.account.service.AccountService;
@@ -18,7 +21,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Account account = accountService.read(username);
+        Account account = accountService.read(Long.parseLong(username));
         return User.of(account);
     }
 }

--- a/src/main/java/com/example/demo/bounded_context/account/entity/Account.java
+++ b/src/main/java/com/example/demo/bounded_context/account/entity/Account.java
@@ -1,6 +1,7 @@
 package com.example.demo.bounded_context.account.entity;
 
-import com.example.demo.base.entity.BaseTimeEntity;
+
+import com.example.demo.base.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/example/demo/bounded_context/auth/service/AuthService.java
+++ b/src/main/java/com/example/demo/bounded_context/auth/service/AuthService.java
@@ -5,6 +5,7 @@ import com.example.demo.base.exception.CustomException;
 import com.example.demo.base.jwt.JwtProvider;
 import com.example.demo.base.refresh_token.RefreshToken;
 import com.example.demo.base.refresh_token.RefreshTokenService;
+import com.example.demo.bounded_context.account.service.AccountService;
 import com.example.demo.bounded_context.auth.dto.SignInAccountRequest;
 import com.example.demo.bounded_context.auth.dto.SignUpAccountRequest;
 import com.example.demo.bounded_context.auth.dto.TokenResponse;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final AccountRepository accountRepository;
+    private final AccountService accountService;
     private final JwtProvider jwtProvider;
     private final RefreshTokenService refreshTokenService;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
@@ -78,9 +80,11 @@ public class AuthService {
      * 인증 메서드
      */
     public User authenticate(SignInAccountRequest request){
+        //loadUserByUsername 을 사용하기 위한 id
+        Long id = accountService.read(request.getAccountName()).getId();
         //인증 객체 셍성 : Authentication 구현 객체 UsernamePasswordAuthenticationToken
         UsernamePasswordAuthenticationToken authenticationToken =
-                new UsernamePasswordAuthenticationToken(request.getAccountName(), request.getPassword());
+                new UsernamePasswordAuthenticationToken(id, request.getPassword());
 
         //인증 : CustomUserDetailsService - loadUserByUsername 사용
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);


### PR DESCRIPTION
### 변경사항
- 오류 수정
    -  JwtFilter 에서 모두 Null 값인 UsernamePasswordAuthenticationToken 객체를 인증정보에 저장시에 인증을 처리하는 오류 발생 null 값에 대한 DB 검사를 시행하지 않았기 때문으로 loadUserByUsername 를 사용하도록 수정
    - String 타입을 갖는 loadUserByUsername을 JWT의 accountId 를 위해 Long 타입으로 바꾸게 되어 sign-in API 에도 오류 발생 DB 검사를 실행하여 id값을 가져오도록 수정
    - claim.get("accountId") 시에 반환 타입은 Object 로 바로 Long 타입으로 바꾸었을 때 오류 발생 String 타입 으로 바꿔주고 Long 타입 으로 바꾸도록 수정
- 미사용 변수 정리
- auth 상수 사용
- gitIgnore : yml 사용 및 mac DS_STORE 추가
- BaseTimeEntity 미적용 오류 수정
    -  @EnableJpaAuditing 추가
    -  경로 오류
- JWT, API 호출 예외 추가 

### 관련이슈