### PR TITLE
Exception 로직 리팩토링 및 추가

### DIFF
--- a/src/main/java/com/example/demo/base/exception/ExceptionCode.java
+++ b/src/main/java/com/example/demo/base/exception/ExceptionCode.java
@@ -6,8 +6,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ExceptionCode {
     //access
-    EMPTY_TOKEN(HttpStatus.BAD_REQUEST, "헤더에 토큰이 존재하지 않습니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 서명의 토큰입니다."),
     WRONG_TOKEN(HttpStatus.UNAUTHORIZED, "올바르지 않은 토큰 형식입니다."),
     EXPIRE_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰 입니다."),
 

--- a/src/main/java/com/example/demo/base/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/demo/base/exception/GlobalExceptionHandler.java
@@ -76,4 +76,10 @@ public class GlobalExceptionHandler {
         ExceptionResponse response = ExceptionResponse.of(ExceptionCode.EXPIRE_ACCESS_TOKEN);
         return ResponseEntity.badRequest().body(response);
     }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ExceptionResponse> handler(Exception e) {
+        ExceptionResponse response = ExceptionResponse.of(e);
+        return ResponseEntity.badRequest().body(response);
+    }
 }

--- a/src/main/java/com/example/demo/base/exception/JwtExceptionProvider.java
+++ b/src/main/java/com/example/demo/base/exception/JwtExceptionProvider.java
@@ -1,0 +1,26 @@
+package com.example.demo.base.exception;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+
+import java.util.Map;
+
+public class JwtExceptionProvider {
+    private static final Map<Class<? extends Exception>, ExceptionCode> exceptionMappings =
+            Map.ofEntries(
+                    Map.entry(SignatureException.class, ExceptionCode.INVALID_TOKEN),
+                    Map.entry(MalformedJwtException.class, ExceptionCode.WRONG_TOKEN),
+                    Map.entry(ExpiredJwtException.class, ExceptionCode.EXPIRE_ACCESS_TOKEN)
+            );
+
+    public static ExceptionResponse generatorExceptionResponse(Exception exception) {
+        if (exception instanceof JwtException){ //인증 관련
+            return ExceptionResponse.of(exceptionMappings.get(exception.getClass()));
+        } else if(exception instanceof CustomException){ //파싱 관련
+            return ExceptionResponse.of(((CustomException) exception).getExceptionCode());
+        }
+        return ExceptionResponse.of(exception);
+    }
+}

--- a/src/main/java/com/example/demo/base/jwt/JwtProvider.java
+++ b/src/main/java/com/example/demo/base/jwt/JwtProvider.java
@@ -28,7 +28,7 @@ public class JwtProvider {
 
     public String parseToken(HttpServletRequest request) {
         if(request.getHeader(AuthConstants.AUTH_HEADER) == null){
-            throw new CustomException(ExceptionCode.EMPTY_TOKEN);
+            throw new CustomException(ExceptionCode.INVALID_HEADER);
         }
         return parseToken(request.getHeader(AuthConstants.AUTH_HEADER));
     }

--- a/src/main/java/com/example/demo/base/security/SecurityConfig.java
+++ b/src/main/java/com/example/demo/base/security/SecurityConfig.java
@@ -4,12 +4,14 @@ package com.example.demo.base.security;
 import com.example.demo.base.blacklist_token.BlacklistTokenService;
 import com.example.demo.base.jwt.JwtProvider;
 import com.example.demo.base.security.filter.JwtTokenFilter;
+import com.example.demo.bounded_context.account.service.AccountService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -28,11 +30,12 @@ public class SecurityConfig {
     private final JwtProvider jwtProvider;
     private final ObjectMapper objectMapper;
     private final BlacklistTokenService blacklistTokenService;
-    private final UserDetailsServiceImpl userDetailsService;
+    private final AccountService accountService;
 
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http.cors(cors -> cors.configurationSource(new CorsConfigurationSource() {
+        http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .cors(cors -> cors.configurationSource(new CorsConfigurationSource() {
                     @Override
                     public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
                         CorsConfiguration config = new CorsConfiguration();
@@ -49,7 +52,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(request -> request
                         .requestMatchers("/api/account/**").authenticated()
                         .anyRequest().permitAll())
-                .addFilterBefore(new JwtTokenFilter(jwtProvider, blacklistTokenService, objectMapper, userDetailsService), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtTokenFilter(jwtProvider, blacklistTokenService, objectMapper, accountService), UsernamePasswordAuthenticationFilter.class)
                 .formLogin(withDefaults())
                 .httpBasic(withDefaults());
 

--- a/src/main/java/com/example/demo/base/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/demo/base/security/UserDetailsServiceImpl.java
@@ -1,8 +1,5 @@
 package com.example.demo.base.security;
 
-import com.example.demo.base.exception.CustomException;
-import com.example.demo.base.exception.ExceptionCode;
-import com.example.demo.base.exception.ExceptionResponse;
 import com.example.demo.bounded_context.account.entity.Account;
 
 import com.example.demo.bounded_context.account.service.AccountService;
@@ -21,7 +18,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Account account = accountService.read(Long.parseLong(username));
+        Account account = accountService.read(username);
         return User.of(account);
     }
 }

--- a/src/main/java/com/example/demo/bounded_context/account/service/AccountService.java
+++ b/src/main/java/com/example/demo/bounded_context/account/service/AccountService.java
@@ -22,7 +22,7 @@ public class AccountService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final BlacklistTokenService blacklistTokenService;
 
-    public Account read(String accountName){
+    public Account read(String accountName){ //loadByUsername
         return accountRepository.findByAccountName(accountName)
                 .orElseThrow(() -> new CustomException(ExceptionCode.ACCOUNT_NOT_FOUND));
     }

--- a/src/main/java/com/example/demo/bounded_context/auth/service/AuthService.java
+++ b/src/main/java/com/example/demo/bounded_context/auth/service/AuthService.java
@@ -80,11 +80,9 @@ public class AuthService {
      * 인증 메서드
      */
     public User authenticate(SignInAccountRequest request){
-        //loadUserByUsername 을 사용하기 위한 id
-        Long id = accountService.read(request.getAccountName()).getId();
         //인증 객체 셍성 : Authentication 구현 객체 UsernamePasswordAuthenticationToken
         UsernamePasswordAuthenticationToken authenticationToken =
-                new UsernamePasswordAuthenticationToken(id, request.getPassword());
+                new UsernamePasswordAuthenticationToken(request.getAccountName(), request.getPassword());
 
         //인증 : CustomUserDetailsService - loadUserByUsername 사용
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);


### PR DESCRIPTION
### 작업사항
- JwtFilter 
    - 관련 예외 종류에 따른 객체 생성으로 if 코드 중복문제 발생 예외 객체를 매핑하여 반환하는 JwtExceptionProvider 를 사용하도록 수정
    - Jwt 파싱 후 accountId 를 사용하므로 accountService.read(Long) 을 사용하도록 수정
- UserDetailsServiceImpl / AuthService : username 으로 조회하므로 accountService.read(String) 을 사용하도록 수정
- JwtProvider : header 의 Authrorization 값이 존재하지 않는 경우 예외 수정
- SecurityConfig : session stateless 설정
- GlobalExceptionHandler : web 에서 was 의 exception 을 확인하기 위한 로직 추가

### 관련이슈