### PR TITLE
회원탈퇴, 정보조회, 정보수정 API 구현

### DIFF
--- a/src/main/java/com/example/demo/base/exception/ExceptionCode.java
+++ b/src/main/java/com/example/demo/base/exception/ExceptionCode.java
@@ -23,6 +23,7 @@ public enum ExceptionCode {
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "유효하지 않은 비밀번호 입니다."),
     BLACK_LIST(HttpStatus.BAD_REQUEST, "무효화된 토큰입니다."),
     INVALID_SIGN_OUT(HttpStatus.BAD_REQUEST, "비정상적인 로그아웃 시도입니다."),
+    INVALID_WITHDRAWAL(HttpStatus.BAD_REQUEST, "비정상적인 회원탈퇴 시도입니다."),
 
     DUPLICATE_NAME(HttpStatus.BAD_REQUEST, "중복된 이름이 존재합니다."),
     EMPTY_LOCATION(HttpStatus.BAD_REQUEST, "위치정보가 존재하지 않습니다."),

--- a/src/main/java/com/example/demo/bounded_context/account/controller/AccountController.java
+++ b/src/main/java/com/example/demo/bounded_context/account/controller/AccountController.java
@@ -3,14 +3,13 @@ package com.example.demo.bounded_context.account.controller;
 import com.example.demo.base.Resolver.AccessToken;
 import com.example.demo.base.Resolver.AuthorizationHeader;
 import com.example.demo.base.common.AuthConstants;
-import com.example.demo.bounded_context.account.entity.Account;
+import com.example.demo.bounded_context.account.dto.AccountInfoDto;
+import com.example.demo.bounded_context.account.dto.AccountInfoRequest;
 import com.example.demo.bounded_context.account.service.AccountService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,21 +17,31 @@ import java.util.List;
 public class AccountController {
     private final AccountService accountService;
 
-    @GetMapping("/list")
-    public List<Account> list(){
-        return accountService.list();
-    }
-
-    @GetMapping("/info")
-    public Account info(@AuthorizationHeader Long id){
-        return accountService.read(id);
-    }
-
     @PostMapping("/sign-out")
     @Operation(summary = "로그아웃", description = "access / refresh token 을 사용한 로그아웃")
     public ResponseEntity signOut(@AuthorizationHeader AccessToken accessToken,
                                   @CookieValue(AuthConstants.REFRESH_TOKEN) String refreshToken) {
         accountService.signOut(accessToken, refreshToken);
         return ResponseEntity.ok().body("로그아웃에 성공했습니다.");
+    }
+
+    @DeleteMapping("/withdrawal")
+    @Operation(summary = "회원 탈퇴", description = "access / refresh token 을 사용한 회원 탈퇴")
+    public ResponseEntity withdrawal(@AuthorizationHeader AccessToken accessToken,
+                                         @CookieValue(AuthConstants.REFRESH_TOKEN) String refreshToken) {
+        accountService.withdrawal(accessToken, refreshToken);
+        return ResponseEntity.ok().body("회원탈퇴에 성공했습니다.");
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "정보 조회", description = "access token 을 사용한 사용자 정보 조회")
+    public ResponseEntity<AccountInfoDto> read(@AuthorizationHeader Long id) {
+        return ResponseEntity.ok().body(AccountInfoDto.of(accountService.read(id)));
+    }
+
+    @PutMapping("/me")
+    @Operation(summary = "정보 수정", description = "access token 을 사용한 사용자 정보 수정")
+    public ResponseEntity update(@AuthorizationHeader Long id, @RequestBody AccountInfoRequest request) {
+        return ResponseEntity.ok().body(AccountInfoDto.of(accountService.update(id, request)));
     }
 }

--- a/src/main/java/com/example/demo/bounded_context/account/dto/AccountInfoDto.java
+++ b/src/main/java/com/example/demo/bounded_context/account/dto/AccountInfoDto.java
@@ -1,0 +1,27 @@
+package com.example.demo.bounded_context.account.dto;
+
+import com.example.demo.bounded_context.account.entity.Account;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AccountInfoDto {
+    String nickname;
+    Double latitude;
+    Double longitude;
+
+    @Builder
+    public AccountInfoDto(String nickname, Double latitude, Double longitude) {
+        this.nickname = nickname;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    public static AccountInfoDto of(Account account){
+        return AccountInfoDto.builder()
+                .nickname(account.getNickname())
+                .latitude(account.getLatitude())
+                .longitude(account.getLongitude())
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/bounded_context/account/dto/AccountInfoDto.java
+++ b/src/main/java/com/example/demo/bounded_context/account/dto/AccountInfoDto.java
@@ -6,12 +6,14 @@ import lombok.Getter;
 
 @Getter
 public class AccountInfoDto {
+    String accountName;
     String nickname;
     Double latitude;
     Double longitude;
 
     @Builder
-    public AccountInfoDto(String nickname, Double latitude, Double longitude) {
+    public AccountInfoDto(String accountName, String nickname, Double latitude, Double longitude) {
+        this.accountName = accountName;
         this.nickname = nickname;
         this.latitude = latitude;
         this.longitude = longitude;
@@ -19,6 +21,7 @@ public class AccountInfoDto {
 
     public static AccountInfoDto of(Account account){
         return AccountInfoDto.builder()
+                .accountName(account.getAccountName())
                 .nickname(account.getNickname())
                 .latitude(account.getLatitude())
                 .longitude(account.getLongitude())

--- a/src/main/java/com/example/demo/bounded_context/account/dto/AccountInfoRequest.java
+++ b/src/main/java/com/example/demo/bounded_context/account/dto/AccountInfoRequest.java
@@ -1,0 +1,15 @@
+package com.example.demo.bounded_context.account.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class AccountInfoRequest {
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "유효한 이메일 주소를 입력해주세요.")
+    private String email;
+    private String nickname;
+    private Double latitude;
+    private Double longitude;
+}

--- a/src/main/java/com/example/demo/bounded_context/account/entity/Account.java
+++ b/src/main/java/com/example/demo/bounded_context/account/entity/Account.java
@@ -2,6 +2,7 @@ package com.example.demo.bounded_context.account.entity;
 
 
 import com.example.demo.base.common.BaseTimeEntity;
+import com.example.demo.bounded_context.account.dto.AccountInfoRequest;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -26,13 +27,21 @@ public class Account extends BaseTimeEntity {
     private Double longitude;
 
     @Builder
-    public Account(String accountName, String password, String email, String nickname, String state, String city, Double latitude, Double longitude) {
+    public Account(String accountName, String password, String email, String nickname, Double latitude, Double longitude) {
         this.accountName = accountName;
         this.password = password;
         this.email = email;
         this.nickname = nickname;
-        this.latitude = latitude;
-        this.longitude = longitude;
+        this.latitude = latitude == null ? 35.8704 : latitude;
+        this.longitude = longitude == null ? 128.5564 : longitude;
+    }
+
+    public Account update(AccountInfoRequest request){
+        this.email = request.getEmail();
+        this.nickname = request.getNickname();
+        this.latitude = request.getLatitude();
+        this.longitude = request.getLongitude();
+        return this;
     }
 }
 

--- a/src/main/java/com/example/demo/bounded_context/account/service/AccountService.java
+++ b/src/main/java/com/example/demo/bounded_context/account/service/AccountService.java
@@ -7,12 +7,11 @@ import com.example.demo.base.exception.ExceptionCode;
 import com.example.demo.base.refresh_token.RefreshToken;
 import com.example.demo.base.refresh_token.RefreshTokenRepository;
 import com.example.demo.base.refresh_token.RefreshTokenService;
+import com.example.demo.bounded_context.account.dto.AccountInfoRequest;
 import com.example.demo.bounded_context.account.entity.Account;
 import com.example.demo.bounded_context.account.repository.AccountRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -27,17 +26,15 @@ public class AccountService {
                 .orElseThrow(() -> new CustomException(ExceptionCode.ACCOUNT_NOT_FOUND));
     }
 
-    public Account read(Long accountName){
-        return accountRepository.findById(accountName)
+    public Account read(Long accountId){
+        return accountRepository.findById(accountId)
                 .orElseThrow(() -> new CustomException(ExceptionCode.ACCOUNT_NOT_FOUND));
     }
 
-    public List<Account> list(){
-        return accountRepository.findAll();
-    }
-
     /**
-     * access / refresh token 로 로그아웃
+     * 로그아웃
+     * 1. access token 정보로 blacklist token 생성
+     * 2. refresh token 삭제
      */
     public void signOut(AccessToken accessToken, String refreshToken){
         RefreshToken refresh = refreshTokenService.read(refreshToken);
@@ -46,5 +43,30 @@ public class AccountService {
         }
         blacklistTokenService.create(accessToken);
         refreshTokenRepository.delete(refresh);
+    }
+
+    /**
+     * 회원탈퇴
+     * 1. refresh token 삭제
+     * 2. account 삭제 - account 를 조회할 수 없으므로 access token 정보로 blacklist token 생성하지 않아도 된다.
+     */
+    public void withdrawal(AccessToken accessToken, String refreshToken){
+        RefreshToken refresh = refreshTokenService.read(refreshToken);
+        if(refresh.getUserId() != accessToken.getAccountId()){
+            throw new CustomException(ExceptionCode.INVALID_SIGN_OUT);
+        }
+        refreshTokenRepository.delete(refresh);
+        remove(refresh.getUserId());
+    }
+
+    public Account update(Long accountId, AccountInfoRequest request){
+        Account account = read(accountId);
+        return accountRepository.save(account.update(request));
+    }
+
+    public Account remove(Long accountId){
+        Account account = read(accountId);
+        accountRepository.delete(account);
+        return account;
     }
 }

--- a/src/main/java/com/example/demo/bounded_context/account/service/AccountService.java
+++ b/src/main/java/com/example/demo/bounded_context/account/service/AccountService.java
@@ -52,7 +52,7 @@ public class AccountService {
     public void withdrawal(AccessToken accessToken, String refreshToken){
         RefreshToken refresh = refreshTokenService.read(refreshToken);
         if(refresh.getAccountId() != accessToken.getAccountId()){
-            throw new CustomException(ExceptionCode.INVALID_SIGN_OUT);
+            throw new CustomException(ExceptionCode.INVALID_WITHDRAWAL);
         }
         refreshTokenService.remove(refresh.getAccountId());
         remove(refresh.getAccountId());

--- a/src/main/java/com/example/demo/bounded_context/account/service/AccountService.java
+++ b/src/main/java/com/example/demo/bounded_context/account/service/AccountService.java
@@ -18,7 +18,6 @@ import org.springframework.stereotype.Service;
 public class AccountService {
     private final AccountRepository accountRepository;
     private final RefreshTokenService refreshTokenService;
-    private final RefreshTokenRepository refreshTokenRepository;
     private final BlacklistTokenService blacklistTokenService;
 
     public Account read(String accountName){ //loadByUsername
@@ -42,7 +41,7 @@ public class AccountService {
             throw new CustomException(ExceptionCode.INVALID_SIGN_OUT);
         }
         blacklistTokenService.create(accessToken);
-        refreshTokenRepository.delete(refresh);
+        refreshTokenService.remove(refresh.getAccountId());
     }
 
     /**
@@ -52,11 +51,11 @@ public class AccountService {
      */
     public void withdrawal(AccessToken accessToken, String refreshToken){
         RefreshToken refresh = refreshTokenService.read(refreshToken);
-        if(refresh.getUserId() != accessToken.getAccountId()){
+        if(refresh.getAccountId() != accessToken.getAccountId()){
             throw new CustomException(ExceptionCode.INVALID_SIGN_OUT);
         }
-        refreshTokenRepository.delete(refresh);
-        remove(refresh.getUserId());
+        refreshTokenService.remove(refresh.getAccountId());
+        remove(refresh.getAccountId());
     }
 
     public Account update(Long accountId, AccountInfoRequest request){


### PR DESCRIPTION
###작업사항
- 사용하지 않는 테스트 API 삭제
- 회원탈퇴
    - access/refresh token 모두 받아 같은 user를 가지는 지 확인 
    - refresh 삭제
    - account 삭제
- 정보조회, 정보수정 API 구현

###관련이슈

